### PR TITLE
fix: update old ValidateTwilioRequestAttribute class name to latest

### DIFF
--- a/ValidateRequestExample/Filters/ValidateTwilioRequestAttribute.cs
+++ b/ValidateRequestExample/Filters/ValidateTwilioRequestAttribute.cs
@@ -14,12 +14,12 @@ using Twilio.Security;
 namespace ValidateRequestExample.Filters
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public class ValidateTwilioRequestAttribute : ActionFilterAttribute
+    public class ValidateTwilioRequestImprovedAttribute : ActionFilterAttribute
     {
         private readonly string _authToken;
         private readonly string _urlSchemeAndDomain;
 
-        public ValidateTwilioRequestAttribute()
+        public ValidateTwilioRequestImprovedAttribute()
         {
             _authToken = ConfigurationManager.AppSettings["TwilioAuthToken"];
             _urlSchemeAndDomain = ConfigurationManager.AppSettings["TwilioBaseUrl"];


### PR DESCRIPTION
@dprothero had a request come in from a hackathon attendee that this class name is out of date. Trying to update.

https://issues.corp.twilio.com/browse/DEVED-5919